### PR TITLE
terminal methods should be delegated to query

### DIFF
--- a/lib/arel-helpers/query_builder.rb
+++ b/lib/arel-helpers/query_builder.rb
@@ -11,6 +11,11 @@ module ArelHelpers
     attr_reader :query
     def_delegators :@query, :to_a, :to_sql, :each
 
+    TERMINAL_METHODS = [:count, :first, :last]
+    TERMINAL_METHODS << :pluck if ActiveRecord::VERSION::MAJOR >= 4
+
+    def_delegators :@query, *TERMINAL_METHODS
+
     def initialize(query)
       @query = query
     end

--- a/spec/query_builder_spec.rb
+++ b/spec/query_builder_spec.rb
@@ -44,4 +44,11 @@ describe ArelHelpers::QueryBuilder do
     Post.create(title: "Foobar")
     builder.map(&:title).should == ["Foobar"]
   end
+
+  ArelHelpers::QueryBuilder::TERMINAL_METHODS.each do |method|
+    it "does not enumerate records for #{method}" do
+      mock(builder).each.never
+      builder.public_send(method)
+    end
+  end
 end


### PR DESCRIPTION
Currently the `QueryBuilder` module does not delegate terminal methods to the `ActiveRecord::Relation` object which results in less efficient queries.

I wanted to write specs to ensure the following sql is generated:

``` ruby
TestQueryBuilder.new.count
# => SELECT COUNT(*) FROM "posts"
```

However, with `count` being a terminal method, we cannot append `to_sql` to inspect the statement.

Any ideas?
