### PR TITLE
Relax ActiveRecord dependency

### DIFF
--- a/arel-helpers.gemspec
+++ b/arel-helpers.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   if ENV["AR"]
     s.add_dependency 'activerecord', ENV["AR"]
   else
-    s.add_dependency 'activerecord', '>= 3.1.0', '<= 4.1.0'
+    s.add_dependency 'activerecord', '>= 3.1.0', '< 5'
   end
 
   s.require_path = 'lib'


### PR DESCRIPTION
While this may not exactly be future proof, it does help if users want to use newer Rails releases i.e. Rails 4.1.1 without hacking the gem just to support a new version. We could update it on every Rails release, but that would suck IMHO.
