### PR TITLE
Force Delegation

### DIFF
--- a/lib/arel-helpers/arel_table.rb
+++ b/lib/arel-helpers/arel_table.rb
@@ -7,6 +7,10 @@ module ArelHelpers
 
     module ClassMethods
 
+      if ActiveRecord.const_defined?(:Delegation)
+        ActiveRecord::Delegation.delegate :[], to: :to_a
+      end
+
       def [](name)
         arel_table[name]
       end

--- a/spec/arel_table_spec.rb
+++ b/spec/arel_table_spec.rb
@@ -21,4 +21,10 @@ describe ArelHelpers::ArelTable do
     comment = post.comments.create
     post.reload.comments[0].id.should == comment.id
   end
+
+  it "does not interfere with ActiveRecord::Relation objects" do
+    Post.all[0].should be_nil
+    p = Post.create(title: 'foo')
+    Post.all[0].id.should == p.id
+  end
 end


### PR DESCRIPTION
`ActiveRecord::Relation` objects use `method_missing` to respond to array-like methods, including `#[]`. The `method_missing` logic checks the model class for `#[]` first, then Array. Since `ArelHelpers::ArelTable` defines `#[]`, an arel column gets returned whenever anyone tries to index into a relation, eg: `Comments.all[0]`.

For more details, see #18.

Thoughts, @svoynow?