### PR TITLE
Add license information to gemspec so it is parsed by verifiers.

### DIFF
--- a/arel-helpers.gemspec
+++ b/arel-helpers.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.authors  = ["Cameron Dutro"]
   s.email    = ["camertron@gmail.com"]
   s.homepage = "http://github.com/camertron"
-
+  s.license  = 'MIT'
   s.description = s.summary = "Useful tools to help construct database queries with ActiveRecord and Arel."
 
   s.platform = Gem::Platform::RUBY


### PR DESCRIPTION
Add the license information to the gemspec so VersionEye and other license verifiers can retrieve it automatically.