### PR TITLE
Remove `has_rdoc` from gem specification

### DIFF
--- a/arel-helpers.gemspec
+++ b/arel-helpers.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.description = s.summary = "Useful tools to help construct database queries with ActiveRecord and Arel."
 
   s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
 
   if ENV["AR"]
     s.add_dependency 'activerecord', ENV["AR"]


### PR DESCRIPTION
RubyGems 2.7.7 [deprecated the has_rdoc property][1] for gem
specifications. As such, loading this gem with a newer version of
RubyGems raises a warning that will eventually be an error. It would be
nice to nip this in the bud.

[1]: https://github.com/ruby/ruby/commit/c6da9cadb346cc1d250c7ed6d8fd33c62a11030e#diff-05477d38d75c98664b0e7dec6eb73b45R2025