### PR TITLE
Allow consumers of ArelHelpers::QueryBuilder to chain on falsy return

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,13 +203,11 @@ If you have parts of a query that should only be added under certain conditions 
   end
 ```
 
-This can become repetetive, and as an alternarive you can choose to extend your `ArelHelpers::QueryBuilder` sub class with `ArelHelpers::DefaultQueryChain`:
+This can become repetitive, and as an alternative you can choose to prepend `not_nil` to your method definition:
 
 ```ruby
   class PostQueryBuilder < ArelHelpers::QueryBuilder
-    extend ArelHelpers::DefaultQueryChain
-
-    chain def with_comments_by(usernames)
+    not_nil def with_comments_by(usernames)
       reflect(query.where(post[:title].matches("%#{title}%"))) if usernames
     end
   end

--- a/README.md
+++ b/README.md
@@ -187,6 +187,34 @@ PostQueryBuilder.new
   .since_yesterday
 ```
 
+#### Conditional reflections
+
+If you have parts of a query that should only be added under certain conditions you can return `reflect(query)` from your method. E.g:
+
+```ruby
+  def with_comments_by(usernames)
+    if usernames
+      reflect(
+        query.where(post[:title].matches("%#{title}%"))
+      )
+    else
+      reflect(query)
+    end
+  end
+```
+
+This can become repetetive, and as an alternarive you can choose to extend your `ArelHelpers::QueryBuilder` sub class with `ArelHelpers::DefaultQueryChain`:
+
+```ruby
+  class PostQueryBuilder < ArelHelpers::QueryBuilder
+    extend ArelHelpers::DefaultQueryChain
+
+    chain def with_comments_by(usernames)
+      reflect(query.where(post[:title].matches("%#{title}%"))) if usernames
+    end
+  end
+```
+
 ## Requirements
 
 Requires ActiveRecord >= 3.1.0, < 6, tested against Ruby 2.2.4. Depends on SQLite for testing purposes.

--- a/lib/arel-helpers/query_builder.rb
+++ b/lib/arel-helpers/query_builder.rb
@@ -4,6 +4,23 @@ require 'forwardable'
 require 'enumerator'
 
 module ArelHelpers
+  module DefaultQueryChain
+    def chain(name)
+      mod = Module.new do
+        define_method(name) do |*args|
+          if (value = super(*args))
+            value
+          else
+            reflect(query)
+          end
+        end
+      end
+
+      prepend mod
+      name
+    end
+  end
+
   class QueryBuilder
     extend Forwardable
     include Enumerable

--- a/lib/arel-helpers/query_builder.rb
+++ b/lib/arel-helpers/query_builder.rb
@@ -4,8 +4,19 @@ require 'forwardable'
 require 'enumerator'
 
 module ArelHelpers
-  module DefaultQueryChain
-    def chain(name)
+  class QueryBuilder
+    extend Forwardable
+    include Enumerable
+
+    attr_reader :query
+    def_delegators :@query, :to_a, :to_sql, :each
+
+    TERMINAL_METHODS = [:count, :first, :last]
+    TERMINAL_METHODS << :pluck if ActiveRecord::VERSION::MAJOR >= 4
+
+    def_delegators :@query, *TERMINAL_METHODS
+
+    def self.not_nil(name)
       mod = Module.new do
         define_method(name) do |*args|
           if (value = super(*args))
@@ -19,19 +30,6 @@ module ArelHelpers
       prepend mod
       name
     end
-  end
-
-  class QueryBuilder
-    extend Forwardable
-    include Enumerable
-
-    attr_reader :query
-    def_delegators :@query, :to_a, :to_sql, :each
-
-    TERMINAL_METHODS = [:count, :first, :last]
-    TERMINAL_METHODS << :pluck if ActiveRecord::VERSION::MAJOR >= 4
-
-    def_delegators :@query, *TERMINAL_METHODS
 
     def initialize(query)
       @query = query

--- a/spec/query_builder_spec.rb
+++ b/spec/query_builder_spec.rb
@@ -3,8 +3,6 @@
 require 'spec_helper'
 
 class TestQueryBuilder < ArelHelpers::QueryBuilder
-  extend ArelHelpers::DefaultQueryChain
-
   attr_accessor :params
   alias_method :params?, :params
 
@@ -16,7 +14,7 @@ class TestQueryBuilder < ArelHelpers::QueryBuilder
     reflect(query)
   end
 
-  chain def optional(skip:)
+  not_nil def optional(skip:)
     reflect(query.where(title: "BarBar")) unless skip
   end
 end

--- a/spec/query_builder_spec.rb
+++ b/spec/query_builder_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 class TestQueryBuilder < ArelHelpers::QueryBuilder
+  extend ArelHelpers::DefaultQueryChain
+
   attr_accessor :params
   alias_method :params?, :params
 
@@ -12,6 +14,10 @@ class TestQueryBuilder < ArelHelpers::QueryBuilder
 
   def noop
     reflect(query)
+  end
+
+  chain def optional(skip:)
+    reflect(query.where(title: "BarBar")) unless skip
   end
 end
 
@@ -56,5 +62,15 @@ describe ArelHelpers::QueryBuilder do
       mock(builder).each.never
       builder.public_send(method)
     end
+  end
+
+  it "returns reflect on existing query if method returns a falsy value" do
+    builder.optional(skip: true).to_sql.strip.should == 'SELECT "posts".* FROM "posts"'
+  end
+
+  it "returns reflect on new query for default chainable method if value is truthy" do
+    builder.optional(skip: false).to_sql.strip.gsub(/\s+/, " ").should == %Q{
+      SELECT \"posts\".* FROM \"posts\" WHERE \"posts\".\"title\" = 'BarBar'
+    }.strip
   end
 end


### PR DESCRIPTION
If you want to optimally chain a number of queries it quickly becomes very noisy to wrap each execution in an if-statements and handle the various returns.

`ArelHelpers::QueryBuilder` is a nice way to avoid that but it can end up with a similar problem. Each query method defines needs to check the desired expression and then either add to the base query or return `reflect(query)`.

This PR adds a utility module that can be extended in the sub class of `ArelHelpers::QueryBuilder`. In that way it doesn’t modify `ArelHelpers::QueryBuilder` at all but proveds an additional opt-in behaviour that works well together with `ArelHelpers::QueryBuilder`.