### PR TITLE
Update arel-helpers.gemspec

### DIFF
--- a/arel-helpers.gemspec
+++ b/arel-helpers.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.platform = Gem::Platform::RUBY
 
-  s.add_dependency 'activerecord', '>= 3.1.0', '< 7'
+  s.add_dependency 'activerecord', '>= 3.1.0', '< 7.1'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'combustion', '~> 1.3'


### PR DESCRIPTION
I'm not sure if there are any AREL API implications to account for, but changing the required ActiveRecord version number allows this to work with Rails v7.0